### PR TITLE
FBCM-5205 Support Consumer with `eachMessage`

### DIFF
--- a/src/Kafka/Consumer.purs
+++ b/src/Kafka/Consumer.purs
@@ -125,6 +125,11 @@ type ConsumerConfigImpl =
 -- | * `eachBatchAutoResolve`
 -- |   * auto commit offsets after successful `eachBatch`
 -- |   * default: `true`
+-- | * `partitionsConsumedConcurrently`
+-- |   * concurrently instead of sequentially invoke `eachBatch`/`eachMessage` for multiple partitions if count is greater than `1`. Messages in the same partition are still guaranteed to be processed in order, but messages from multiple partitions can be processed at the same time.
+-- |   * should not be larger than the number of partitions consumed
+-- |   * default: `1`
+-- |   * see [Partition-aware concurrency](https://kafka.js.org/docs/consuming#a-name-concurrent-processing-a-partition-aware-concurrency)
 type ConsumerRunConfig =
   { autoCommit ::
       Data.Maybe.Maybe
@@ -133,6 +138,7 @@ type ConsumerRunConfig =
         }
   , eachBatch :: EachBatchHandler
   , eachBatchAutoResolve :: Data.Maybe.Maybe Boolean
+  , partitionsConsumedConcurrently :: Data.Maybe.Maybe Int
   }
 
 -- | https://github.com/tulios/kafkajs/blob/dcee6971c4a739ebb02d9279f68155e3945c50f7/types/index.d.ts#L1016
@@ -145,13 +151,10 @@ type ConsumerRunConfig =
 -- |   * in milliseconds
 -- | * `eachBatch?: EachBatchHandler`
 -- | * `eachBatchAutoResolve?: boolean`
+-- | * `partitionsConsumedConcurrently?: number`
 -- |
 -- | Unsupported
 -- | * `eachMessage?: EachMessageHandler`
--- | * `partitionsConsumedConcurrently?: number`
--- |   * concurrently instead of sequentially invoke `eachMessage` if count is greater than `1`
--- |   * default: `1`
--- |   * see [Partition-aware concurrency](https://kafka.js.org/docs/consuming#a-name-concurrent-processing-a-partition-aware-concurrency)
 type ConsumerRunConfigImpl =
   Kafka.FFI.Object
     ()
@@ -160,6 +163,7 @@ type ConsumerRunConfigImpl =
     , autoCommitThreshold :: Number
     , eachBatch :: EachBatchHandlerImpl
     , eachBatchAutoResolve :: Boolean
+    , partitionsConsumedConcurrently :: Int
     )
 
 -- | * `fromBeginning`
@@ -525,6 +529,7 @@ run consumer' consumerRunConfig =
     , autoCommitThreshold: x.autoCommit >>= _.autoCommitThreshold
     , eachBatch: toEachBatchHandlerImpl x.eachBatch
     , eachBatchAutoResolve: x.eachBatchAutoResolve
+    , partitionsConsumedConcurrently: x.partitionsConsumedConcurrently
     }
 
   toEachBatchHandlerImpl :: EachBatchHandler -> EachBatchHandlerImpl

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -222,25 +222,27 @@ testSuite = do
         }
       Kafka.Consumer.run consumer
         { autoCommit: Data.Maybe.Nothing
-        , eachBatch: \eachBatchPayload -> do
-            (newMessages :: Array { key :: String, value :: String }) <-
-              map Data.Array.catMaybes
-                $ Data.Traversable.for eachBatchPayload.batch.messages \message -> do
-                    let
-                      maybeKeyValue :: Data.Maybe.Maybe { key :: Node.Buffer.Buffer, value :: Node.Buffer.Buffer }
-                      maybeKeyValue = do
-                        key <- message.key
-                        value <- message.value
-                        pure { key, value }
-                    Data.Traversable.for maybeKeyValue \keyValue -> do
-                      key <- Effect.Class.liftEffect $
-                        Node.Buffer.toString Node.Encoding.UTF8 keyValue.key
-                      value <- Effect.Class.liftEffect $
-                        Node.Buffer.toString Node.Encoding.UTF8 keyValue.value
-                      pure { key, value }
-            Effect.Class.liftEffect $
-              Effect.Ref.modify_ (_ <> newMessages) receivedRef
-        , eachBatchAutoResolve: Data.Maybe.Just true
+        , consume: Kafka.Consumer.EachBatch
+            { autoResolve: Data.Maybe.Just true
+            , handler: \eachBatchPayload -> do
+                (newMessages :: Array { key :: String, value :: String }) <-
+                  map Data.Array.catMaybes
+                    $ Data.Traversable.for eachBatchPayload.batch.messages \message -> do
+                        let
+                          maybeKeyValue :: Data.Maybe.Maybe { key :: Node.Buffer.Buffer, value :: Node.Buffer.Buffer }
+                          maybeKeyValue = do
+                            key <- message.key
+                            value <- message.value
+                            pure { key, value }
+                        Data.Traversable.for maybeKeyValue \keyValue -> do
+                          key <- Effect.Class.liftEffect $
+                            Node.Buffer.toString Node.Encoding.UTF8 keyValue.key
+                          value <- Effect.Class.liftEffect $
+                            Node.Buffer.toString Node.Encoding.UTF8 keyValue.value
+                          pure { key, value }
+                Effect.Class.liftEffect $
+                  Effect.Ref.modify_ (_ <> newMessages) receivedRef
+            }
         , partitionsConsumedConcurrently: Data.Maybe.Nothing
         }
       Effect.Aff.delay (Effect.Aff.Milliseconds 1000.0)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -241,6 +241,7 @@ testSuite = do
             Effect.Class.liftEffect $
               Effect.Ref.modify_ (_ <> newMessages) receivedRef
         , eachBatchAutoResolve: Data.Maybe.Just true
+        , partitionsConsumedConcurrently: Data.Maybe.Nothing
         }
       Effect.Aff.delay (Effect.Aff.Milliseconds 1000.0)
     received <- Effect.Class.liftEffect $


### PR DESCRIPTION
## What does this pull request do?

Support `eachMessage` handler in `Kafka.Consumer.run`.
