### PR TITLE
FBCM-5200 Support Transaction

### DIFF
--- a/spago.dhall
+++ b/spago.dhall
@@ -29,6 +29,7 @@ to generate this file without the comments in this block.
     , "nullable"
     , "option"
     , "prelude"
+    , "record"
     , "refs"
     , "st"
     , "strings"

--- a/src/Kafka/Consumer.purs
+++ b/src/Kafka/Consumer.purs
@@ -291,7 +291,7 @@ type EachBatchPayloadImpl =
   , isStale :: Effect.Effect Boolean
   , pause :: Effect.Effect (Effect.Effect Unit)
   , resolveOffset :: Effect.Uncurried.EffectFn1 String Unit
-  , uncommittedOffsets :: Effect.Effect OffsetsByTopicParitionImpl
+  , uncommittedOffsets :: Effect.Effect OffsetsByTopicParition
   }
 
 type EachMessageHandler =
@@ -431,30 +431,21 @@ type Offsets =
 type OffsetsImpl =
   Kafka.FFI.Object
     ()
-    ( topics :: Array TopicOffsetsImpl
+    ( topics :: Array TopicOffsets
     )
-
-type OffsetsByTopicParition =
-  { topics :: Array TopicOffsets
-  }
 
 -- | https://github.com/tulios/kafkajs/blob/d8fd93e7ce8e4675e3bb9b13d7a1e55a1e0f6bbf/types/index.d.ts#L843
 -- |
 -- | `topics: TopicOffsets[]`
-type OffsetsByTopicParitionImpl =
-  { topics :: Array TopicOffsetsImpl
-  }
-
-type PartitionOffset =
-  { offset :: String
-  , partition :: Int
+type OffsetsByTopicParition =
+  { topics :: Array TopicOffsets
   }
 
 -- | https://github.com/tulios/kafkajs/blob/d8fd93e7ce8e4675e3bb9b13d7a1e55a1e0f6bbf/types/index.d.ts#L650
 -- |
 -- | * `offset: string`
 -- | * `partition: number`
-type PartitionOffsetsImpl =
+type PartitionOffset =
   { offset :: String
   , partition :: Int
   }
@@ -463,17 +454,12 @@ data Topic
   = TopicName String
   | TopicRegex Data.String.Regex.Regex
 
-type TopicOffsets =
-  { partitions :: Array PartitionOffset
-  , topic :: String
-  }
-
 -- | https://github.com/tulios/kafkajs/blob/d8fd93e7ce8e4675e3bb9b13d7a1e55a1e0f6bbf/types/index.d.ts#L655
 -- |
 -- | * `partitions: PartitionOffset[]`
 -- | * `topic: string`
-type TopicOffsetsImpl =
-  { partitions :: Array PartitionOffsetsImpl
+type TopicOffsets =
+  { partitions :: Array PartitionOffset
   , topic :: String
   }
 

--- a/src/Kafka/Producer.purs
+++ b/src/Kafka/Producer.purs
@@ -135,7 +135,7 @@ foreign import data Producer :: Type
 -- |   * default: `CompressionTypeNone`
 -- | * `timeout`
 -- |   * The time to await a response in ms
--- |   * default: `30000`
+-- |   * default: `Milliseconds 30000`
 -- | * `topicMessages`
 -- |   * a list of topics and for each topic a list of messages
 type ProducerBatch =
@@ -174,10 +174,10 @@ type ProducerBatchImpl =
 -- |   * default: `Nothing`
 -- | * `metadataMaxAge`
 -- |   * The period of time in milliseconds after which we force a refresh of metadata even if we haven't seen any partition leadership changes to proactively discover any new brokers or partitions
--- |   * default: `300000`
+-- |   * default: `Milliseconds 300000`
 -- | * `transactionTimeout`
 -- |   * The maximum amount of time in ms that the transaction coordinator will wait for a transaction status update from the producer before proactively aborting the ongoing transaction. If this value is larger than the `transaction.max.timeout.ms` setting in the broker, the request will fail with a `InvalidTransactionTimeout` error
--- |   * default: `60000`
+-- |   * default: `Milliseconds 60000`
 -- | * `transactionalId`
 -- |   * The `transactionalId` allows Kafka to fence out zombie instances by rejecting writes from producers with the same `transactionalId`, allowing only writes from the most recently registered producer. To ensure EoS (Exactly-once Semantics) in a stream processing application, it is important that the `transactionalId` is always the same for a given input topic and partition in the read-process-write cycle.
 -- |   * see [Choosing a `transactionalId`](https://kafka.js.org/docs/transactions#choosing-a-transactionalid)
@@ -226,7 +226,7 @@ type ProducerConfigImpl =
 -- |   * a list of messages to be sent
 -- | * `timeout`
 -- |   * The time to await a response in ms
--- |   * default: `30000`
+-- |   * default: `Milliseconds 30000`
 -- | * `topic`
 -- |   * topic name
 type ProducerRecord =

--- a/src/Kafka/Producer.purs
+++ b/src/Kafka/Producer.purs
@@ -34,6 +34,7 @@ import Node.Buffer as Node.Buffer
 import Untagged.Union as Untagged.Union
 
 -- | Control the number of required acks.
+-- | Acks is shorthand for acknowledgments, the number of brokers (leader/follower replicas) that must receive the message before the write is considered as successful.
 -- | * `AcksAll`
 -- |   * all insync replicas must acknowledge
 -- | * `AcksNo`

--- a/src/Kafka/Producer.purs
+++ b/src/Kafka/Producer.purs
@@ -167,11 +167,11 @@ type ProducerBatchImpl =
 -- |   * Allow topic creation when querying metadata for non-existent topics
 -- |   * default: `true`
 -- | * `idempotent`
--- |   * If enabled producer will ensure each message is written exactly once. Acks must be set to `-1` ("all"). Retries will default to `MAX_SAFE_INTEGER`.
+-- |   * If enabled producer will ensure each message is written exactly once. Acks must be set to `AcksAll`. Retries will default to `MAX_SAFE_INTEGER`.
 -- |   * default: `false`
 -- | * `maxInFlightRequests`
--- |   * Max number of requests that may be in progress at any time. If falsey then no limit.
--- |   * default: `null` (no limit)
+-- |   * Max number of requests that may be in progress at any time. If `Nothing` then no limit.
+-- |   * default: `Nothing`
 -- | * `metadataMaxAge`
 -- |   * The period of time in milliseconds after which we force a refresh of metadata even if we haven't seen any partition leadership changes to proactively discover any new brokers or partitions
 -- |   * default: `300000`

--- a/src/Kafka/Producer.purs
+++ b/src/Kafka/Producer.purs
@@ -51,9 +51,24 @@ derive instance ordAcks :: Ord Acks
 
 type AcksImpl = Int
 
+-- | See [Compression](https://kafka.js.org/docs/producing#a-name-compression-a-compression)
+-- |
+-- | * `CompressionTypeNone`
+-- |   * no compression
+-- | * `CompressionTypeGzip`
+-- |   * natively supported by Kafka
+-- | * `CompressionTypeSnappy`
+-- |   * need to install `kafkajs-snappy` on `npm` and follow the instructions there to mutate `CompressionCodecs` object in `kafkajs`
+-- | * `CompressionTypeLz4`
+-- |   * need to install `kafkajs-lz4` on `npm` and follow the instructions there to mutate `CompressionCodecs` object in `kafkajs`
+-- | * `CompressionTypeZstd`
+-- |   * need to install `@kafkajs/zstd` on `npm` and follow the instructions there to mutate `CompressionCodecs` object in `kafkajs`
 data CompressionType
   = CompressionTypeNone
   | CompressionTypeGzip
+  | CompressionTypeSnappy
+  | CompressionTypeLz4
+  | CompressionTypeZstd
 
 derive instance eqCompressionType :: Eq CompressionType
 derive instance ordCompressionType :: Ord CompressionType
@@ -63,9 +78,6 @@ derive instance ordCompressionType :: Ord CompressionType
 -- |
 -- | https://github.com/tulios/kafkajs/blob/dcee6971c4a739ebb02d9279f68155e3945c50f7/src/protocol/message/compression/index.js#L5
 -- | `Compression.Types`
--- |
--- | NOTE only `GZIP` is implemented
--- | see [`Compression.Codecs`](https://github.com/tulios/kafkajs/blob/dcee6971c4a739ebb02d9279f68155e3945c50f7/src/protocol/message/compression/index.js#L13-L24)
 type CompressionTypeImpl = Int
 
 -- | see [Message structure](https://kafka.js.org/docs/producing#message-structure)
@@ -401,10 +413,16 @@ sendBatch producer' producerBatch = do
   -- |
   -- | None = 0
   -- | GZIP = 1
+  -- | Snappy = 2
+  -- | LZ4 = 3
+  -- | ZSTD = 4
   toCompressionTypeImpl :: CompressionType -> CompressionTypeImpl
   toCompressionTypeImpl = case _ of
     CompressionTypeNone -> 0
     CompressionTypeGzip -> 1
+    CompressionTypeSnappy -> 2
+    CompressionTypeLz4 -> 3
+    CompressionTypeZstd -> 4
 
   toMessageImpl :: Message -> MessageImpl
   toMessageImpl x = Kafka.FFI.objectFromRecord

--- a/src/Kafka/Transaction.js
+++ b/src/Kafka/Transaction.js
@@ -8,6 +8,10 @@ exports._commit = function _commit(transaction) {
   return transaction.commit();
 };
 
+exports._sendOffsets = function _sendOffsets(transaction, offsets) {
+  return transaction.sendOffsets(offsets);
+};
+
 exports._transaction = function _transaction(producer) {
   return producer.transaction();
 };

--- a/src/Kafka/Transaction.js
+++ b/src/Kafka/Transaction.js
@@ -1,0 +1,13 @@
+"use strict";
+
+exports._abort = function _abort(transaction) {
+  return transaction.abort();
+};
+
+exports._commit = function _commit(transaction) {
+  return transaction.commit();
+};
+
+exports._transaction = function _transaction(producer) {
+  return producer.transaction();
+};

--- a/src/Kafka/Transaction.purs
+++ b/src/Kafka/Transaction.purs
@@ -1,16 +1,64 @@
 module Kafka.Transaction
-  ( Transaction
+  ( ProducerBatch
+  , ProducerConfig
+  , ProducerRecord
+  , Transaction
   , abort
   , commit
+  , producer
+  , send
+  , sendBatch
   , transaction
   ) where
 
 import Prelude
 
 import Control.Promise as Control.Promise
+import Data.Maybe as Data.Maybe
+import Data.Time.Duration as Data.Time.Duration
+import Effect as Effect
 import Effect.Aff as Effect.Aff
 import Effect.Uncurried as Effect.Uncurried
+import Kafka.Kafka as Kafka.Kafka
 import Kafka.Producer as Kafka.Producer
+import Record as Record
+
+-- | `Kafka.Producer.ProducerBatch` with the following defaults
+-- | * `acks` set to `AcksAll`
+-- |
+-- | see [Transactions](https://kafka.js.org/docs/transactions)
+type ProducerBatch =
+  { compression :: Data.Maybe.Maybe Kafka.Producer.CompressionType
+  , timeout :: Data.Maybe.Maybe Data.Time.Duration.Milliseconds
+  , topicMessages :: Array Kafka.Producer.TopicMessages
+  }
+
+-- | `Kafka.Producer.ProducerConfig` with following defaults
+-- | * `idempotent` set to `true`
+-- |   * Retries will default to `MAX_SAFE_INTEGER`. See https://github.com/tulios/kafkajs/blob/ddf4f64923245ce2cf5716d5babd7e05eb890030/src/producer/index.js#L43
+-- | * `maxInFlightRequests` set to `1`
+-- |
+-- | Required
+-- | * `transactionalId`
+-- |
+-- | see [Transactions](https://kafka.js.org/docs/transactions)
+type ProducerConfig =
+  { allowAutoTopicCreation :: Data.Maybe.Maybe Boolean
+  , metadataMaxAge :: Data.Maybe.Maybe Data.Time.Duration.Milliseconds
+  , transactionTimeout :: Data.Maybe.Maybe Data.Time.Duration.Milliseconds
+  , transactionalId :: String
+  }
+
+-- | `Kafka.Producer.ProducerRecord` with the following defaults
+-- | * `acks` set to `AcksAll`
+-- |
+-- | see [Transactions](https://kafka.js.org/docs/transactions)
+type ProducerRecord =
+  { compression :: Data.Maybe.Maybe Kafka.Producer.CompressionType
+  , messages :: Array Kafka.Producer.Message
+  , timeout :: Data.Maybe.Maybe Data.Time.Duration.Milliseconds
+  , topic :: String
+  }
 
 foreign import data Transaction :: Type
 
@@ -34,6 +82,30 @@ commit transaction' =
   Control.Promise.toAffE
     $ Effect.Uncurried.runEffectFn1 _commit transaction'
 
+producer ::
+  Kafka.Kafka.Kafka ->
+  ProducerConfig ->
+  Effect.Effect Kafka.Producer.Producer
+producer kafka producerConfig =
+  Kafka.Producer.producer kafka
+    $ (_ { transactionalId = Data.Maybe.Just producerConfig.transactionalId })
+    $ Record.disjointUnion producerConfig
+        { idempotent: Data.Maybe.Just true
+        , maxInFlightRequests: Data.Maybe.Just 1
+        }
+
+send :: Kafka.Producer.Producer -> ProducerRecord -> Effect.Aff.Aff (Array Kafka.Producer.RecordMetadata)
+send producer' producerRecord =
+  Kafka.Producer.send producer'
+    $ Record.disjointUnion producerRecord
+        { acks: Data.Maybe.Just Kafka.Producer.AcksAll }
+
+sendBatch :: Kafka.Producer.Producer -> ProducerBatch -> Effect.Aff.Aff (Array Kafka.Producer.RecordMetadata)
+sendBatch producer' producerBatch =
+  Kafka.Producer.sendBatch producer'
+    $ Record.disjointUnion producerBatch
+        { acks: Data.Maybe.Just Kafka.Producer.AcksAll }
+
 foreign import _transaction ::
   Effect.Uncurried.EffectFn1
     Kafka.Producer.Producer
@@ -42,6 +114,6 @@ foreign import _transaction ::
 transaction ::
   Kafka.Producer.Producer ->
   Effect.Aff.Aff Transaction
-transaction producer =
+transaction producer' =
   Control.Promise.toAffE
-    $ Effect.Uncurried.runEffectFn1 _transaction producer
+    $ Effect.Uncurried.runEffectFn1 _transaction producer'

--- a/src/Kafka/Transaction.purs
+++ b/src/Kafka/Transaction.purs
@@ -1,0 +1,47 @@
+module Kafka.Transaction
+  ( Transaction
+  , abort
+  , commit
+  , transaction
+  ) where
+
+import Prelude
+
+import Control.Promise as Control.Promise
+import Effect.Aff as Effect.Aff
+import Effect.Uncurried as Effect.Uncurried
+import Kafka.Producer as Kafka.Producer
+
+foreign import data Transaction :: Type
+
+foreign import _abort ::
+  Effect.Uncurried.EffectFn1
+    Transaction
+    (Control.Promise.Promise Unit)
+
+abort :: Transaction -> Effect.Aff.Aff Unit
+abort transaction' =
+  Control.Promise.toAffE
+    $ Effect.Uncurried.runEffectFn1 _abort transaction'
+
+foreign import _commit ::
+  Effect.Uncurried.EffectFn1
+    Transaction
+    (Control.Promise.Promise Unit)
+
+commit :: Transaction -> Effect.Aff.Aff Unit
+commit transaction' =
+  Control.Promise.toAffE
+    $ Effect.Uncurried.runEffectFn1 _commit transaction'
+
+foreign import _transaction ::
+  Effect.Uncurried.EffectFn1
+    Kafka.Producer.Producer
+    (Control.Promise.Promise Transaction)
+
+transaction ::
+  Kafka.Producer.Producer ->
+  Effect.Aff.Aff Transaction
+transaction producer =
+  Control.Promise.toAffE
+    $ Effect.Uncurried.runEffectFn1 _transaction producer

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -210,6 +210,7 @@ testSuite = do
             , timestamp: Data.Maybe.Nothing
             , value: Data.Maybe.Just $ Kafka.Producer.String message.value
             }
+        , timeout: Data.Maybe.Nothing
         , topic
         }
     receivedRef <- Effect.Class.liftEffect $

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -198,7 +198,14 @@ testSuite = do
         }
       Test.Unit.Assert.assert "Topic is already created" created
     producer <- Effect.Class.liftEffect $
-      Kafka.Producer.producer kafka {}
+      Kafka.Producer.producer kafka
+        { allowAutoTopicCreation: Data.Maybe.Just false
+        , idempotent: Data.Maybe.Nothing
+        , maxInFlightRequests: Data.Maybe.Nothing
+        , metadataMaxAge: Data.Maybe.Nothing
+        , transactionTimeout: Data.Maybe.Nothing
+        , transactionalId: Data.Maybe.Nothing
+        }
     Effect.Aff.bracket (Kafka.Producer.connect producer) (\_ -> Kafka.Producer.disconnect producer) \_ -> do
       void $ Kafka.Producer.send producer
         { acks: Data.Maybe.Nothing

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -201,7 +201,8 @@ testSuite = do
       Kafka.Producer.producer kafka {}
     Effect.Aff.bracket (Kafka.Producer.connect producer) (\_ -> Kafka.Producer.disconnect producer) \_ -> do
       void $ Kafka.Producer.send producer
-        { messages: messages <#> \message ->
+        { acks: Data.Maybe.Nothing
+        , messages: messages <#> \message ->
             { headers: Data.Maybe.Nothing
             , key: Data.Maybe.Just $ Kafka.Producer.String message.key
             , partition: Data.Maybe.Nothing

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -202,6 +202,7 @@ testSuite = do
     Effect.Aff.bracket (Kafka.Producer.connect producer) (\_ -> Kafka.Producer.disconnect producer) \_ -> do
       void $ Kafka.Producer.send producer
         { acks: Data.Maybe.Nothing
+        , compression: Data.Maybe.Nothing
         , messages: messages <#> \message ->
             { headers: Data.Maybe.Nothing
             , key: Data.Maybe.Just $ Kafka.Producer.String message.key


### PR DESCRIPTION
## What does this pull request do?

Add `Kafka.Transaction` for writing a batch of messages to multiple downstream topics/partitions as an atomic action. To achieve EoS (Exactly-once Semantics) in read-process-write pattern (a stream transformer that processes messages read from upstream topics/partitions and then write new messages to downstream topics/partitions), `Kafka.Transaction.sendOffsets` will only commit read offsets when the whole transaction succeeds thus allows retries without producing duplicate messages to downstream topics/partitions.
