### PR TITLE
FBCM-5201 Support `consumer.seek`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "kafkajs": "2.2.3",
-        "purescript": "0.14.1",
+        "purescript": "0.14.9",
         "purs-tidy": "0.9.0",
         "spago": "0.20.9"
       }
@@ -1711,9 +1711,9 @@
       }
     },
     "node_modules/purescript": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.14.1.tgz",
-      "integrity": "sha512-dh87XeDP/JGe/3DKBMglkRuIRfGLGkL8beuLIl9KemzckgyuD+j7VK15eVb9n5Exp3DIr6SNEuGG4FjuQQ7Rpg==",
+      "version": "0.14.9",
+      "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.14.9.tgz",
+      "integrity": "sha512-r0J2JX/QuKYBSj8LDDYKQAY+tz/RtIm9erHrqWV7Y8RpUc6TZu14AxWcnSrohbBcEXImY/o0pMpouZrUeyriKQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "author": "CitizenNet",
   "license": "Apache-2.0",
   "devDependencies": {
-    "purescript": "0.14.1",
+    "purescript": "0.14.9",
     "purs-tidy": "0.9.0",
     "kafkajs": "2.2.3",
     "spago": "0.20.9"

--- a/spago.dhall
+++ b/spago.dhall
@@ -23,6 +23,7 @@ to generate this file without the comments in this block.
     , "foldable-traversable"
     , "foreign-object"
     , "integers"
+    , "js-timers"
     , "maybe"
     , "node-buffer"
     , "node-child-process"

--- a/src/Kafka/Consumer.js
+++ b/src/Kafka/Consumer.js
@@ -12,6 +12,10 @@ exports._disconnect = function _connect(consumer) {
   return consumer.disconnect();
 };
 
+exports._onGroupJoin = function _onGroupJoin(consumer, listener) {
+  return consumer.on(consumer.events.GROUP_JOIN, listener);
+};
+
 exports._run = function _run(consumer, config) {
   return consumer.run(config);
 };

--- a/src/Kafka/Consumer.js
+++ b/src/Kafka/Consumer.js
@@ -16,6 +16,10 @@ exports._run = function _run(consumer, config) {
   return consumer.run(config);
 };
 
+exports._seek = function _seek(consumer, topicPartitionOffset) {
+  return consumer.seek(topicPartitionOffset);
+};
+
 exports._subscribe = function _subscribe(consumer, subscription) {
   return consumer.subscribe(subscription);
 };

--- a/src/Kafka/Consumer.js
+++ b/src/Kafka/Consumer.js
@@ -12,6 +12,10 @@ exports._disconnect = function _connect(consumer) {
   return consumer.disconnect();
 };
 
+exports._onCrash = function _onCrash(consumer, listener) {
+  return consumer.on(consumer.events.CRASH, listener);
+};
+
 exports._onGroupJoin = function _onGroupJoin(consumer, listener) {
   return consumer.on(consumer.events.GROUP_JOIN, listener);
 };

--- a/src/Kafka/Consumer.purs
+++ b/src/Kafka/Consumer.purs
@@ -16,6 +16,7 @@ module Kafka.Consumer
   , connect
   , consumer
   , disconnect
+  , onGroupJoin
   , run
   , seek
   , subscribe
@@ -27,6 +28,7 @@ import Control.Promise as Control.Promise
 import Data.Maybe as Data.Maybe
 import Data.Nullable as Data.Nullable
 import Data.String.Regex as Data.String.Regex
+import Data.Time.Duration as Data.Time.Duration
 import Effect as Effect
 import Effect.Aff as Effect.Aff
 import Effect.Uncurried as Effect.Uncurried
@@ -139,6 +141,75 @@ type ConsumerConfig =
 -- | * `sessionTimeout?: number`
 type ConsumerConfigImpl =
   { groupId :: String }
+
+-- | * `duration`
+-- |   * time lapsed since requested to join the Consumer Group
+-- | * `groupId`
+-- |   * Consumer Group ID which should match the one specified in the `ConsumerConfig`
+-- | * `groupProtocol`
+-- |   * Partition Assigner protocol name e.g. "RoundRobinAssigner"
+-- | * `isLeader`
+-- |   * is the Consumer Group Leader which is responsible for executing rebalance activity. Consumer Group Leader will take a list of current members, assign partitions to them and send it back to the coordinator. The Coordinator then communicates back to the members about their new partitions.
+-- | * `leaderId`
+-- |   * Member ID of the Consumer Group Leader
+-- | * `memberAssignment`
+-- |   * topic-partitions assigned to this Consumer
+-- | * `memberId`
+-- |   * Member ID of this Consumer in the Consumer Group
+type ConsumerGroupJoinEvent =
+  { duration :: Data.Time.Duration.Milliseconds
+  , groupId :: String
+  , groupProtocol :: String
+  , isLeader :: Boolean
+  , leaderId :: String
+  , memberAssignment :: ConsumerGroupJoinEventMemberAssignment
+  , memberId :: String
+  }
+
+-- | https://github.com/tulios/kafkajs/blob/dcee6971c4a739ebb02d9279f68155e3945c50f7/types/index.d.ts#L931
+-- |
+-- | `type ConsumerGroupJoinEvent = InstrumentationEvent<{...}>`
+-- | * `duration: number`
+-- | * `groupId: string`
+-- | * `groupProtocol: string`
+-- | * `isLeader: boolean`
+-- | * `leaderId: string`
+-- | * `memberAssignment: IMemberAssignment`
+-- | * `memberId: string`
+-- |
+-- | https://github.com/tulios/kafkajs/blob/1ab72f2c3925685b730937dd34481a4faa0ddb03/src/consumer/consumerGroup.js#L338-L353
+type ConsumerGroupJoinEventImpl =
+  InstrumentationEventImpl
+    { duration :: Number
+    , groupId :: String
+    , groupProtocol :: String
+    , isLeader :: Boolean
+    , leaderId :: String
+    , memberAssignment :: ConsumerGroupJoinEventMemberAssignment
+    , memberId :: String
+    }
+
+type ConsumerGroupJoinEventListener =
+  ConsumerGroupJoinEvent -> Effect.Effect Unit
+
+-- | https://github.com/tulios/kafkajs/blob/dcee6971c4a739ebb02d9279f68155e3945c50f7/types/index.d.ts#L1054
+-- |
+-- | `(event: ConsumerGroupJoinEvent) => void`
+type ConsumerGroupJoinEventListenerImpl =
+  Effect.Uncurried.EffectFn1
+    ConsumerGroupJoinEventImpl
+    Unit
+
+-- | https://github.com/tulios/kafkajs/blob/dcee6971c4a739ebb02d9279f68155e3945c50f7/types/index.d.ts#L928
+-- |
+-- | ```
+-- | export interface IMemberAssignment {
+-- |   [key: string]: number[]
+-- | }
+-- | ```
+type ConsumerGroupJoinEventMemberAssignment =
+  Foreign.Object.Object
+    (Array Int)
 
 -- | * `autoCommit`
 -- |   * auto commit offsets periodically during a batch
@@ -343,6 +414,21 @@ type EachMessagePayloadImpl =
   , topic :: String
   }
 
+-- | https://github.com/tulios/kafkajs/blob/dcee6971c4a739ebb02d9279f68155e3945c50f7/types/index.d.ts#L382
+-- |
+-- | `interface InstrumentationEvent<T>`
+-- | * `id: string`
+-- |   * globally incremental ID, see https://github.com/tulios/kafkajs/blob/4246f921f4d66a95f32f159c890d0a3a83803713/src/instrumentation/event.js#L16
+-- | * `payload: T`
+-- | * `timestamp: number`
+-- | * `type: string`
+type InstrumentationEventImpl payload =
+  { id :: String
+  , payload :: payload
+  , timestamp :: Number
+  , type :: String
+  }
+
 -- | * `headers`
 -- | * `key`
 -- | * `offset`
@@ -456,6 +542,10 @@ type PartitionOffset =
   , partition :: Int
   }
 
+-- | https://github.com/tulios/kafkajs/blob/dcee6971c4a739ebb02d9279f68155e3945c50f7/types/index.d.ts#L389
+-- | `type RemoveInstrumentationEventListener<T> = () => void`
+type RemoveInstrumentationEventListener = Effect.Effect Unit
+
 data Topic
   = TopicName String
   | TopicRegex Data.String.Regex.Regex
@@ -526,6 +616,50 @@ disconnect :: Consumer -> Effect.Aff.Aff Unit
 disconnect consumer' =
   Control.Promise.toAffE
     $ Effect.Uncurried.runEffectFn1 _disconnect consumer'
+
+-- | https://github.com/tulios/kafkajs/blob/dcee6971c4a739ebb02d9279f68155e3945c50f7/types/index.d.ts#L1052-L1055
+-- |
+-- | ```
+-- | on(
+-- |   eventName: ConsumerEvents['GROUP_JOIN'],
+-- |   listener: (event: ConsumerGroupJoinEvent) => void
+-- | ): RemoveInstrumentationEventListener<typeof eventName>
+-- | ```
+foreign import _onGroupJoin ::
+  Effect.Uncurried.EffectFn2
+    Consumer
+    ConsumerGroupJoinEventListenerImpl
+    RemoveInstrumentationEventListener
+
+onGroupJoin ::
+  Consumer ->
+  ConsumerGroupJoinEventListener ->
+  Effect.Effect { removeListener :: Effect.Effect Unit }
+onGroupJoin consumer' consumerGroupJoinEventListener = do
+  removeListener <- Effect.Uncurried.runEffectFn2 _onGroupJoin consumer'
+    $ toConsumerGroupJoinEventListenerImpl consumerGroupJoinEventListener
+  pure { removeListener }
+  where
+  fromConsumerGropuJoinEventImpl ::
+    ConsumerGroupJoinEventImpl ->
+    ConsumerGroupJoinEvent
+  fromConsumerGropuJoinEventImpl x =
+    { duration: Data.Time.Duration.Milliseconds x.payload.duration
+    , groupId: x.payload.groupId
+    , groupProtocol: x.payload.groupProtocol
+    , isLeader: x.payload.isLeader
+    , leaderId: x.payload.leaderId
+    , memberAssignment: x.payload.memberAssignment
+    , memberId: x.payload.memberId
+    }
+
+  toConsumerGroupJoinEventListenerImpl ::
+    ConsumerGroupJoinEventListener ->
+    ConsumerGroupJoinEventListenerImpl
+  toConsumerGroupJoinEventListenerImpl listener =
+    Effect.Uncurried.mkEffectFn1 \eventImpl ->
+      listener
+        $ fromConsumerGropuJoinEventImpl eventImpl
 
 -- | https://github.com/tulios/kafkajs/blob/dcee6971c4a739ebb02d9279f68155e3945c50f7/types/index.d.ts#L1037
 -- |

--- a/src/Kafka/Consumer.purs
+++ b/src/Kafka/Consumer.purs
@@ -12,10 +12,12 @@ module Kafka.Consumer
   , PartitionOffset
   , Topic(..)
   , TopicOffsets
+  , TopicPartitionOffset
   , connect
   , consumer
   , disconnect
   , run
+  , seek
   , subscribe
   ) where
 
@@ -467,6 +469,21 @@ type TopicOffsets =
   , topic :: String
   }
 
+-- | https://github.com/tulios/kafkajs/blob/dcee6971c4a739ebb02d9279f68155e3945c50f7/types/index.d.ts#L869
+-- | 
+-- | `TopicPartition & { offset: string }`
+-- |
+-- | https://github.com/tulios/kafkajs/blob/dcee6971c4a739ebb02d9279f68155e3945c50f7/types/index.d.ts#L865
+-- | 
+-- | `TopicPartition`
+-- | * `topic: string`
+-- | * `partition: number`
+type TopicPartitionOffset =
+  { offset :: String
+  , partition :: Int
+  , topic :: String
+  }
+
 -- | https://github.com/tulios/kafkajs/blob/dcee6971c4a739ebb02d9279f68155e3945c50f7/types/index.d.ts#L1033
 -- |
 -- | `connect(): Promise<void>`
@@ -619,6 +636,19 @@ run consumer' consumerRunConfig =
       Control.Promise.fromAff
         $ eachMessageHandler
         $ fromEachMessagePayloadImpl eachMessagePayloadImpl
+
+-- | https://github.com/tulios/kafkajs/blob/dcee6971c4a739ebb02d9279f68155e3945c50f7/types/index.d.ts#L1039
+-- |
+-- | `seek(topicPartitionOffset: TopicPartitionOffset): void`
+foreign import _seek ::
+  Effect.Uncurried.EffectFn2
+    Consumer
+    TopicPartitionOffset
+    Unit
+
+seek :: Consumer -> TopicPartitionOffset -> Effect.Effect Unit
+seek consumer' topicPartitionOffset =
+  Effect.Uncurried.runEffectFn2 _seek consumer' topicPartitionOffset
 
 -- | https://github.com/tulios/kafkajs/blob/dcee6971c4a739ebb02d9279f68155e3945c50f7/types/index.d.ts#L1035
 -- |

--- a/src/Kafka/Transaction.purs
+++ b/src/Kafka/Transaction.purs
@@ -93,8 +93,12 @@ type TopicOffsets =
   , topic :: String
   }
 
+-- | https://github.com/tulios/kafkajs/blob/dcee6971c4a739ebb02d9279f68155e3945c50f7/types/index.d.ts#L820
 foreign import data Transaction :: Type
 
+-- | https://github.com/tulios/kafkajs/blob/dcee6971c4a739ebb02d9279f68155e3945c50f7/types/index.d.ts#L823
+-- |
+-- | `abort(): Promise<void>`
 foreign import _abort ::
   Effect.Uncurried.EffectFn1
     Transaction
@@ -105,6 +109,9 @@ abort transaction' =
   Control.Promise.toAffE
     $ Effect.Uncurried.runEffectFn1 _abort transaction'
 
+-- | https://github.com/tulios/kafkajs/blob/dcee6971c4a739ebb02d9279f68155e3945c50f7/types/index.d.ts#L822
+-- |
+-- | `commit(): Promise<void>`
 foreign import _commit ::
   Effect.Uncurried.EffectFn1
     Transaction
@@ -139,6 +146,9 @@ sendBatch producer' producerBatch =
     $ Record.disjointUnion producerBatch
         { acks: Data.Maybe.Just Kafka.Producer.AcksAll }
 
+-- | https://github.com/tulios/kafkajs/blob/dcee6971c4a739ebb02d9279f68155e3945c50f7/types/index.d.ts#L821
+-- |
+-- | `sendOffsets(offsets: Offsets & { consumerGroupId: string }): Promise<void>`
 foreign import _sendOffsets ::
   Effect.Uncurried.EffectFn2
     Transaction
@@ -155,6 +165,9 @@ sendOffsets transaction' offsets =
   Control.Promise.toAffE
     $ Effect.Uncurried.runEffectFn2 _sendOffsets transaction' offsets
 
+-- | https://github.com/tulios/kafkajs/blob/dcee6971c4a739ebb02d9279f68155e3945c50f7/types/index.d.ts#L816
+-- |
+-- | `transaction(): Promise<Transaction>`
 foreign import _transaction ::
   Effect.Uncurried.EffectFn1
     Kafka.Producer.Producer


### PR DESCRIPTION
## What does this pull request do?

Add `Kafka.Consumer.seek` for moving the resolved offset (in memory but not committed to broker) of a topic/partition assigned to a Consumer to the specified offset, so the next (batch of) message(s) read from the topic/partition starts at the specified offset.

Also add some test helper functions.