### PR TITLE
Move `kafka` from `devDependencies` to `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "purescript-kafkajs",
   "author": "CitizenNet",
   "license": "Apache-2.0",
+  "dependencies": {
+    "kafkajs": "2.2.3"
+  },
   "devDependencies": {
     "purescript": "0.14.9",
     "purs-tidy": "0.9.0",
-    "kafkajs": "2.2.3",
     "spago": "0.20.9"
   }
 }


### PR DESCRIPTION
## What does this pull request do?

Move `kafka` from `devDependencies` to `dependencies`.